### PR TITLE
Changing rate flag from int to float

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ messages published with perf-test can be consumed by `omq` or vice versa, and th
       --publisher-uri string                URI for publishing
   -x, --publishers int                      The number of publishers to start (default 1)
       --queue-durability queue-durability   Queue durability (default: configuration - the queue definition is durable) (default configuration)
-  -r, --rate int                            Messages per second (-1 = unlimited) (default -1)
+  -r, --rate float                          Messages per second (-1 = unlimited) (default -1)
   -s, --size int                            Message payload size in bytes (default 12)
       --stream-filter-value-set string      Stream filter value for publisher
       --stream-filter-values string         Stream consumer filter

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -196,7 +196,7 @@ func RootCmd() *cobra.Command {
 	rootCmd.PersistentFlags().
 		StringVarP(&cfg.ConsumeFrom, "consume-from", "T", "/topic/omq", "The queue/topic/terminus to consume from (%d will be replaced with the consumer's id)")
 	rootCmd.PersistentFlags().IntVarP(&cfg.Size, "size", "s", 12, "Message payload size in bytes")
-	rootCmd.PersistentFlags().IntVarP(&cfg.Rate, "rate", "r", -1, "Messages per second (-1 = unlimited)")
+	rootCmd.PersistentFlags().Float32VarP(&cfg.Rate, "rate", "r", -1, "Messages per second (-1 = unlimited)")
 	rootCmd.PersistentFlags().DurationVarP(&cfg.Duration, "time", "z", 0, "Run duration (eg. 10s, 5m, 2h)")
 	rootCmd.PersistentFlags().
 		BoolVarP(&cfg.UseMillis, "use-millis", "m", false, "Use milliseconds for timestamps (automatically enabled when no publishers or no consumers)")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -41,7 +41,7 @@ type Config struct {
 	ConsumerCredits      int
 	ConsumerLatency      time.Duration
 	Size                 int
-	Rate                 int
+	Rate                 float32
 	Duration             time.Duration
 	UseMillis            bool
 	QueueDurability      AmqpDurabilityMode


### PR DESCRIPTION
WHY?
Below 1/s rates can be useful in scenarios with many clients with few messages ("IoT").

WHAT?
To allow publishing rate to be less than 1, for example 0.1.
Changes the rate data type from int to float.

OTHER
Rate still can't be 0.